### PR TITLE
Readme list formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,9 +725,9 @@ Ember lifeline also provides mixins, which extend the object's methods to includ
 
 To use any of the above mentioned functions in your component, route or service, simply import and apply one or all of these mixins to your class:
 
-`ContextBoundTasksMixin` for using any of the *Task methods
-`ContextBoundEventListenersMixin` for using addEventListener
-`DisposableMixin` for using registerDisposable and runDisposable
+* `ContextBoundTasksMixin` for using any of the *Task methods
+* `ContextBoundEventListenersMixin` for using addEventListener
+* `DisposableMixin` for using registerDisposable and runDisposable
 
 ### Testing
 


### PR DESCRIPTION
These lines get collapsed into a single line due to how Mardown deals with line breaks.

A proper way to format them is a list. Alternatively, double spaces can be added to the end of each line in order to prevent collapsing.