### PR TITLE
Add optional `map` property to expose the `registeredDisposables` map to tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,6 +754,18 @@ module('module', function(hooks) {
 
 If a failure occurs, lifeline will output an array containing the module names that were the cause of the async leakage.
 
+You may also, optionally, pass in an options hash:
+```js
+module('module', function(hooks) {
+  let disposableMap = new Map();
+  setupLifelineValidation(hooks, { map: disposableMap });
+
+  test('test', function(assert) {
+    assert.equal(disposableMap.size, 0);
+  });
+});
+```
+
 ## Credit
 
 This addon was developed internally at Twitch, written originally by [@mixonic](https://github.com/mixonic) and [@rwjblue](https://github.com/rwjblue).

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -5,8 +5,23 @@ const FAILED_ASSERTION_MESSAGE =
   'One or more objects registered disposables that were not correctly disposed of. Please ensure that objects correctly run their registered disposables by calling `runDisposables` in the `destroy` method of the object.';
 let setupTestDone = false;
 
-export default function setupLifelineValidation(hooks) {
-  let registeredDisposables = new Map();
+/**
+ * Test helper to assert that all async work is disposed of.
+ *
+ * @method setupLifelineValidation
+ * @param { QUnit.hooks } hooks Qunit's hooks object.
+ * @param { Map } options.map Optional map object to use for external reference.
+ * @public
+ */
+export default function setupLifelineValidation(hooks, options) {
+  let registeredDisposables;
+
+  if (options && options.map instanceof Map) {
+    registeredDisposables = options.map;
+  } else {
+    registeredDisposables = new Map();
+  }
+
   hooks.beforeEach(function() {
     _setRegisteredDisposables(registeredDisposables);
   });
@@ -31,8 +46,7 @@ export default function setupLifelineValidation(hooks) {
 
       assert.deepEqual(retainedObjects, [], FAILED_ASSERTION_MESSAGE);
     } finally {
-      registeredDisposables = new WeakMap();
-      _setRegisteredDisposables(registeredDisposables);
+      _setRegisteredDisposables(new WeakMap());
     }
   });
 }

--- a/tests/unit/setup-lifeline-validation-options-test.js
+++ b/tests/unit/setup-lifeline-validation-options-test.js
@@ -1,0 +1,32 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupLifelineValidation from 'ember-lifeline/test-support';
+import { registerDisposable } from 'ember-lifeline';
+
+module('setupLifelineValidation options', function(hooks) {
+  let disposableMap = new Map();
+  setupLifelineValidation(hooks, { map: disposableMap });
+  setupTest(hooks);
+
+  hooks.beforeEach(function(assert) {
+    let serviceName = 'service:under-test';
+    this.owner.register(serviceName, Service.extend());
+    let factory = this.owner.factoryFor
+      ? this.owner.factoryFor(serviceName)
+      : this.owner._lookupFactory(serviceName);
+
+    this.service = factory.create();
+  });
+
+  test('setupLifelineValidation allows passing in a custom map', function(assert) {
+    assert.expect(3);
+
+    assert.equal(disposableMap.size, 0, 'Sanity check.');
+    registerDisposable(this.service, () => {});
+    assert.equal(disposableMap.size, 1, 'The map is exposed to user code.');
+
+    // Manually clear the disposables map so as not to trigger the built-in assertion.
+    disposableMap.clear();
+  });
+});


### PR DESCRIPTION
This is a point of discussion, though I figured it would be easier to discuss with a concrete proposal.

The idea here is to be able to have insight into the registered disposables in testing. It consequentially exposes a lot more `ember-lifeline` internals to possible test-user-land code. That's my goal, but it of course has tradeoffs in terms of either:
- Implied public API which now has to remain stable.
- Exposed non-public API which is unstable that people may depend on nonetheless.

It's a power-user feature, so documenting it in the `README` may not be something we want to do. Obscuring its existence may be good enough to say, "hey, you're on your own here."

I'm not tremendously attached to this proposal, and strong opinions in opposition to this (if they exist) should carry the day.