### PR TITLE
Bugfix: checking for pollers to be defined before calling cancelPoll

### DIFF
--- a/addon/poll-task.ts
+++ b/addon/poll-task.ts
@@ -202,7 +202,10 @@ export function cancelPoll(
   } else {
     let pollers: Set<Token> = registeredPollers.get(obj);
     token = _token as Token;
-    pollers.delete(token);
+
+    if (pollers !== undefined) {
+      pollers.delete(token);
+    }
   }
   delete queuedPollTasks[token];
 }

--- a/tests/unit/poll-task-test.js
+++ b/tests/unit/poll-task-test.js
@@ -17,6 +17,8 @@ module('ember-lifeline/poll-task', function(hooks) {
   hooks.beforeEach(function() {
     this.BaseObject = EmberObject.extend({
       destroy() {
+        this._super(...arguments);
+
         runDisposables(this);
       },
     });
@@ -288,6 +290,20 @@ module('ember-lifeline/poll-task', function(hooks) {
       0,
       'Set deleted the token after task cancelled'
     );
+
+    _setRegisteredPollers(new WeakMap());
+  });
+
+  test('cancelPoll can be safely called without a previous call to pollTask', function(assert) {
+    assert.expect(1);
+
+    let map = new Map();
+    _setRegisteredPollers(map);
+    this.obj = this.getComponent();
+
+    cancelPoll(this.obj, 'foo');
+
+    assert.ok(true, 'cancelPoll was called without first calling pollTask');
 
     _setRegisteredPollers(new WeakMap());
   });

--- a/tests/unit/poll-task-test.js
+++ b/tests/unit/poll-task-test.js
@@ -297,14 +297,10 @@ module('ember-lifeline/poll-task', function(hooks) {
   test('cancelPoll can be safely called without a previous call to pollTask', function(assert) {
     assert.expect(1);
 
-    let map = new Map();
-    _setRegisteredPollers(map);
     this.obj = this.getComponent();
 
     cancelPoll(this.obj, 'foo');
 
     assert.ok(true, 'cancelPoll was called without first calling pollTask');
-
-    _setRegisteredPollers(new WeakMap());
   });
 });


### PR DESCRIPTION
Calling `cancelPoll` before calling `pollTask` results in `pollers` being undefined, as the set is only initialized via `pollTask`. This fix adds a check to ensure `pollers` is not undefined before calling delete on the set.