### PR TITLE
Update usage of `runDisposable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ import { runTask, runDisposables } from 'ember-lifeline';
 export default Component.extend({
   // use `runTask` method somewhere in this component
 
-  destroy() {
-    runDisposables(this); // ensure that lifeline will clean up any remaining async work
-
+  willDestroy() {
     this._super(...arguments);
+    runDisposables(this); // ensure that lifeline will clean up any remaining async work
   }
 })
 ```
@@ -162,10 +161,10 @@ export default Component.extend({
     }, 500);
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -237,10 +236,10 @@ export default Component.extend({
     });
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -287,10 +286,10 @@ export default Component.extend({
     this.set('time', new Date());
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -322,10 +321,10 @@ export default Component.extend({
     this.set('time', new Date());
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -355,10 +354,10 @@ export default Component.extend({
     this._evt = null;
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -397,10 +396,10 @@ export default Component.extend({
     runTask(this, () => this.updateTime(), 20);
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -433,10 +432,10 @@ export default Component.extend({
     }
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -471,10 +470,10 @@ export default Component.extend({
     runTask(this, next, 20);
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 });
 ```
@@ -604,10 +603,10 @@ export default Component.extend({
     this.bindEvents();
   },
 
-  destroy() {
-    runDisposables(this);
-
+  willDestroy() {
     this._super(...arguments);
+
+    runDisposables(this);
   }
 
   bindEvents() {

--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -40,7 +40,9 @@ const registeredDebounces: IMap<Object, Object> = new WeakMap<Object, any>();
        debounceTask(this, 'logMe', 300);
      },
 
-     destroy() {
+     willDestroy() {
+       this._super(...arguments);
+
        runDisposables(this);
      }
    });
@@ -118,7 +120,8 @@ export function debounceTask(
         cancelDebounce(this, 'logMe');
      },
 
-     destroy() {
+     willDestroy() {
+       this._super(..arguments);
        runDisposables(this);
      }
    });

--- a/addon/run-task.ts
+++ b/addon/run-task.ts
@@ -46,7 +46,8 @@ export function _setRegisteredTimers(
        }, 5000)
      },
 
-     destroy() {
+     willDestroy() {
+       this._super(...arguments);
        runDisposables(this);
      }
    });
@@ -97,7 +98,8 @@ export function runTask(
        })
      },
 
-     destroy() {
+     willDestroy() {
+       this._super(...arguments);
        runDisposables(this);
      }
    });
@@ -223,7 +225,8 @@ export function throttleTask(
         cancelTask(this, this._cancelId);
      },
 
-     destroy() {
+     willDestroy() {
+       this._super(...arguments);
        runDisposables(this);
      }
    });


### PR DESCRIPTION
Updating usage of `runDisposable` API to be more intuitive. Given the ordering of clean up doesn't matter any longer, calling `this._super(...arguments)` before `runDisposable` makes it more straightforward to understand.

cc: @scalvert 