### PR TITLE
feat(debounceTask, throttleTask): accept function

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Therefore, *`scheduleTask` is prohibited from scheduling work on the `afterRende
 
 ### `debounceTask`
 
-**tl;dr Call `debounceTask(obj, methodName, args*, wait, immediate)` on any object to debounce work.**
+**tl;dr Call `debounceTask(obj, methodNameOrFunction, args*, wait, immediate)` on any object to debounce work.**
 
 Debouncing is a common async pattern often used to manage user input. When a
 task is debounced with a timeout of 100ms, it first schedules the work for
@@ -300,7 +300,7 @@ cancelled.
 
 ### `throttleTask`
 
-**tl;dr Call `throttleTask(obj, methodName, args*, spacing, immediate)` on any object to throttle work.**
+**tl;dr Call `throttleTask(obj, methodNameOrFunction, args*, spacing, immediate)` on any object to throttle work.**
 
 When a task is throttled, it is executed immediately. For the length of the
 timeout, additional throttle calls are ignored. Again, like debounce, throttle

--- a/addon/mixins/run.ts
+++ b/addon/mixins/run.ts
@@ -133,13 +133,13 @@ export default Mixin.create({
    ```
 
    @method debounceTask
-   @param { String } name the name of the task to debounce
+   @param { String | Function } methodNameOrFunction the name of the task or function to debounce
    @param { ...* } debounceArgs arguments to pass to the debounced method
    @param { Number } wait the amount of time to wait before calling the method (in milliseconds)
    @public
    */
-  debounceTask(name, ...debounceArgs) {
-    debounceTask(this, name, ...debounceArgs);
+  debounceTask(methodNameOrFunction, ...debounceArgs) {
+    debounceTask(this, methodNameOrFunction, ...debounceArgs);
   },
 
   /**
@@ -167,11 +167,11 @@ export default Mixin.create({
    ```
 
    @method cancelDebounce
-   @param { String } methodName the name of the debounced method to cancel
+   @param { String | Function } methodNameOrFunction the name of the debounced method or function reference to cancel
    @public
    */
-  cancelDebounce(name) {
-    cancelDebounce(this, name);
+  cancelDebounce(methodNameOrFunction) {
+    cancelDebounce(this, methodNameOrFunction);
   },
 
   /**
@@ -196,12 +196,12 @@ export default Mixin.create({
    ```
 
    @method throttleTask
-   @param { String } name the name of the task to throttle
+   @param { String | Function } methodNameOrFunction the name of the task or function referenceto throttle
    @param { Number } [timeout] the time in the future to run the task
    @public
    */
-  throttleTask(name, timeout) {
-    return throttleTask(this, name, timeout);
+  throttleTask(methodNameOrFunction, timeout) {
+    return throttleTask(this, methodNameOrFunction, timeout);
   },
 
   /**

--- a/addon/run-task.ts
+++ b/addon/run-task.ts
@@ -175,22 +175,22 @@ export function scheduleTask(
 
    @method throttleTask
    @param { Object } obj the instance to register the task for
-   @param { String } taskName the name of the task to throttle
+   @param { String | Function } taskNameOrFunction the name of the task or a function to throttle
    @param { Number } [timeout] the time in the future to run the task
    @public
    */
-export function throttleTask(
-  obj: EmberObject,
-  taskName: any,
+export function throttleTask<O extends EmberObject>(
+  obj: O,
+  taskNameOrFunction: keyof O | ((...args: any[]) => any),
   timeout: number = 0
 ): EmberRunTimer {
   assert(
-    `Called \`throttleTask\` without a string as the first argument on ${obj}.`,
-    typeof taskName === 'string'
+    `Called \`throttleTask\` without a string or function as the first argument on ${obj}.`,
+    typeof taskNameOrFunction === 'string' || typeof taskNameOrFunction === 'function'
   );
   assert(
-    `Called \`throttleTask('${taskName}', ${timeout})\` where '${taskName}' is not a function.`,
-    typeof obj[taskName] === 'function'
+    `Called \`throttleTask('${taskNameOrFunction}', ${timeout})\` where '${taskNameOrFunction}' is not a function.`,
+    typeof taskNameOrFunction === 'function' || typeof obj[taskNameOrFunction] === 'function'
   );
   assert(
     `Called \`throttleTask\` on destroyed object: ${obj}.`,
@@ -198,7 +198,7 @@ export function throttleTask(
   );
 
   let timers: Set<EmberRunTimer> = getTimers(obj);
-  let cancelId: EmberRunTimer = throttle(obj, taskName, timeout);
+  let cancelId: EmberRunTimer = throttle(obj, taskNameOrFunction, timeout);
 
   timers.add(cancelId);
 

--- a/tests/unit/debounce-task-test.js
+++ b/tests/unit/debounce-task-test.js
@@ -46,6 +46,33 @@ module('ember-lifeline/debounce-task', function(hooks) {
     }, 10);
   });
 
+  test('debounceTask accepts functions', function(assert) {
+    assert.expect(4);
+
+    let done = assert.async();
+    let runCount = 0;
+    let runArg;
+    let obj = (this.obj = this.getComponent());
+
+    function doStuff(arg) {
+      runCount++;
+      assert.equal(this, obj, 'context is correct');
+      runArg = arg;
+    }
+    debounceTask(this.obj, doStuff, 'arg1', 5);
+    debounceTask(this.obj, doStuff, 'arg2', 5);
+    debounceTask(this.obj, doStuff, 'arg3', 5);
+
+    assert.equal(runCount, 0, 'should not have run');
+
+    window.setTimeout(() => {
+      assert.equal(runCount, 1, 'should have run only once');
+      assert.equal(runArg, 'arg3', 'should run the task with the last arg');
+      done();
+    }, 10);
+  });
+
+
   test('debounceTask can be canceled', function(assert) {
     let done = assert.async();
     assert.expect(2);

--- a/tests/unit/mixins/run-test.js
+++ b/tests/unit/mixins/run-test.js
@@ -302,14 +302,17 @@ module('ember-lifeline/mixins/run', function(hooks) {
     }, 10);
   });
 
-  test('debounceTask triggers an assertion when a string is not the first argument', function(assert) {
+  test('debounceTask triggers an assertion when a string or function is not the first argument', function(assert) {
     let component = this.getComponent({
       doStuff() {},
     });
 
+    component.debounceTask(component.doStuff, 5);
+    component.debounceTask('doStuff', 5);
+
     assert.throws(() => {
-      component.debounceTask(component.doStuff, 5);
-    }, /without a string as the first argument/);
+      component.debounceTask({}, 5);
+    }, /without a string or function as the first argument/);
   });
 
   test('debounceTask triggers an assertion the function name provided does not exist on the object', function(assert) {

--- a/tests/unit/run-task-test.js
+++ b/tests/unit/run-task-test.js
@@ -212,12 +212,15 @@ module('ember-lifeline/run-task', function(hooks) {
     });
   });
 
-  test('throttleTask triggers an assertion when a string is not the first argument', function(assert) {
-    this.obj = this.getComponent({ doStuff() {} });
+  test('throttleTask triggers an assertion when a string or a function is not the first argument', function(assert) {
+    this.obj = this.getComponent({ doStuff() { } });
+
+    throttleTask(this.obj, 'doStuff', 5);
+    throttleTask(this.obj, this.obj.doStuff, 5);
 
     assert.throws(() => {
-      throttleTask(this.obj, this.obj.doStuff, 5);
-    }, /without a string as the first argument/);
+      throttleTask(this.obj, {}, 5);
+    }, /without a string or function as the first argument/);
   });
 
   test('throttleTask triggers an assertion the function name provided does not exist on the object', function(assert) {


### PR DESCRIPTION
While writing tests for [`ember-lifeline-decorators`](https://github.com/buschtoens/ember-lifeline-decorators#debounce), I discovered (much to my horror! 😱), that my beloved `ember-lifeline` does not accept functions for `debounceTask` and `throttleTask`.

This PR removes this grievance. 😄 