### PR TITLE
fix: IE11 support

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -25,8 +25,9 @@ export default function setupLifelineValidation(hooks) {
 
   hooks.afterEach(function(assert) {
     try {
-      let retainedObjects = [...registeredDisposables.keys()].map(o =>
-        o.toString()
+      let retainedObjects = [];
+      registeredDisposables.forEach((_, k) =>
+        retainedObjects.push(k.toString())
       );
 
       assert.deepEqual(retainedObjects, [], FAILED_ASSERTION_MESSAGE);

--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -4,12 +4,12 @@ import { assert } from '@ember/debug';
 import { registerDisposable } from './utils/disposable';
 import { IMap } from './interfaces';
 
-type PendingDebounce =
-  | {
-      debouncedTask: Function;
-      cancelId: EmberRunTimer;
-    }
-  | undefined;
+interface PendingDebounce {
+  debouncedTask: Function;
+  cancelId: EmberRunTimer;
+}
+
+type PendingDebounces = Map<string, PendingDebounce>;
 
 /**
  * A map of instances/debounce functions that allows us to
@@ -18,7 +18,7 @@ type PendingDebounce =
  * @private
  *
  */
-const registeredDebounces: IMap<Object, Object> = new WeakMap<Object, any>();
+const registeredDebounces: IMap<Object, PendingDebounces> = new WeakMap<Object, any>();
 
 /**
    Runs the function with the provided name after the timeout has expired on the last
@@ -73,19 +73,19 @@ export function debounceTask(
     !obj.isDestroyed
   );
 
-  let pendingDebounces: Object = registeredDebounces.get(obj);
+  let pendingDebounces: PendingDebounces = registeredDebounces.get(obj);
   if (!pendingDebounces) {
     pendingDebounces = new Map();
     registeredDebounces.set(obj, pendingDebounces);
     registerDisposable(obj, getDebouncesDisposable(pendingDebounces));
   }
 
-  let pendingDebounce: PendingDebounce = pendingDebounces[name];
+  let pendingDebounce: PendingDebounce | undefined = pendingDebounces.get(name);
   let debouncedTask: Function;
 
   if (!pendingDebounce) {
     debouncedTask = (...args) => {
-      delete pendingDebounces[name];
+      pendingDebounces.delete(name);
       obj[name](...args);
     };
   } else {
@@ -95,7 +95,7 @@ export function debounceTask(
   // cancelId is new, even if the debounced function was already present
   let cancelId = debounce(obj as any, debouncedTask as any, ...debounceArgs);
 
-  pendingDebounces[name] = { debouncedTask, cancelId };
+  pendingDebounces.set(name, { debouncedTask, cancelId });
 }
 
 /**
@@ -136,29 +136,28 @@ export function cancelDebounce(
   obj: EmberObject,
   name: string
 ): void | undefined {
-  let pendingDebounces: Object = registeredDebounces.get(obj);
-
-  if (pendingDebounces === undefined || pendingDebounces[name] === undefined) {
+  if (!registeredDebounces.has(obj)) {
     return;
   }
+  const pendingDebounces: PendingDebounces = registeredDebounces.get(obj);
 
-  let { cancelId } = pendingDebounces[name];
+  if (!pendingDebounces.has(name)) {
+    return;
+  }
+  // @ts-ignore
+  const { cancelId } = pendingDebounces.get(name);
 
-  delete pendingDebounces[name];
+  pendingDebounces.delete(name);
   cancel(cancelId);
 }
 
-function getDebouncesDisposable(debounces: Object): Function {
-  return function() {
-    let debounceNames = debounces && Object.keys(debounces);
-
-    if (!debounceNames || !debounceNames.length) {
+function getDebouncesDisposable(debounces: PendingDebounces): Function {
+  return function () {
+    if (!debounces.size) {
       return;
     }
 
-    for (let i = 0; i < debounceNames.length; i++) {
-      let { cancelId } = debounces[debounceNames[i]];
-
+    for (const { cancelId } of debounces.values()) {
       cancel(cancelId);
     }
   };

--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -9,8 +9,6 @@ interface PendingDebounce {
   cancelId: EmberRunTimer;
 }
 
-type PendingDebounces = Map<string, PendingDebounce>;
-
 /**
  * A map of instances/debounce functions that allows us to
  * store pending debounces per instance.
@@ -18,7 +16,10 @@ type PendingDebounces = Map<string, PendingDebounce>;
  * @private
  *
  */
-const registeredDebounces: IMap<Object, PendingDebounces> = new WeakMap<Object, any>();
+const registeredDebounces: IMap<
+  Object,
+  Map<string, PendingDebounce>
+> = new WeakMap<Object, any>();
 
 /**
    Runs the function with the provided name after the timeout has expired on the last
@@ -149,8 +150,10 @@ export function cancelDebounce(
   cancel(cancelId);
 }
 
-function getDebouncesDisposable(debounces: PendingDebounces): Function {
-  return function () {
+function getDebouncesDisposable(
+  debounces: Map<string, PendingDebounce>
+): Function {
+  return function() {
     if (debounces.size === 0) {
       return;
     }

--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -73,7 +73,7 @@ export function debounceTask(
     !obj.isDestroyed
   );
 
-  let pendingDebounces: PendingDebounces = registeredDebounces.get(obj);
+  let pendingDebounces = registeredDebounces.get(obj);
   if (!pendingDebounces) {
     pendingDebounces = new Map();
     registeredDebounces.set(obj, pendingDebounces);
@@ -138,7 +138,7 @@ export function cancelDebounce(
   if (!registeredDebounces.has(obj)) {
     return;
   }
-  const pendingDebounces: PendingDebounces = registeredDebounces.get(obj);
+  const pendingDebounces = registeredDebounces.get(obj);
 
   if (!pendingDebounces.has(name)) {
     return;

--- a/addon/dom-event-listeners.ts
+++ b/addon/dom-event-listeners.ts
@@ -12,7 +12,7 @@ import { IMap } from './interfaces';
  */
 const eventListeners: IMap<Object, Array<Object>> = new WeakMap<Object, any>();
 
-const PASSIVE_SUPPORTED: boolean = (() => {
+export const PASSIVE_SUPPORTED: boolean = (() => {
   let ret: boolean = false;
 
   try {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,11 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let options = {};
+  let options = {
+    'ember-cli-babel': {
+      includePolyfill: true
+    }
+  };
 
   if (defaults.project.findAddonByName('ember-native-dom-event-dispatcher')) {
     options.vendorFiles = { 'jquery.js': null };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,11 +4,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  let options = {
-    'ember-cli-babel': {
-      includePolyfill: true
-    }
-  };
+  let options = {};
 
   if (defaults.project.findAddonByName('ember-native-dom-event-dispatcher')) {
     options.vendorFiles = { 'jquery.js': null };
@@ -22,6 +18,8 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
+
+  app.import({ test: 'vendor/fix-promise.js' });
 
   return app.toTree();
 };

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,9 +1,18 @@
-/* eslint-env node */
+'use strict';
+
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
 module.exports = {
-  browsers: [
-    'ie 11',
-    'last 1 Chrome versions',
-    'last 1 Firefox versions',
-    'last 1 Safari versions',
-  ],
+  browsers
 };

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 module.exports = {
   browsers: [
-    'ie 9',
+    'ie 11',
     'last 1 Chrome versions',
     'last 1 Firefox versions',
     'last 1 Safari versions',

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -3,7 +3,7 @@ import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, triggerEvent } from '@ember/test-helpers';
 import {
@@ -11,6 +11,7 @@ import {
   addEventListener,
   removeEventListener,
 } from 'ember-lifeline';
+import { PASSIVE_SUPPORTED } from 'ember-lifeline/dom-event-listeners';
 
 module('ember-lifeline/dom-event-listeners', function(hooks) {
   setupRenderingTest(hooks);
@@ -77,7 +78,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
         testedOptions
       );
 
-      component.element.firstChild.dispatchEvent(new Event('click'));
+      await triggerEvent(component.element.firstChild, 'click');
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -460,7 +461,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
     assert.equal(innerCalls, 1, 'inner callback fires');
   });
 
-  test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
+  (PASSIVE_SUPPORTED ? test : skip)('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
     assert.expect(2);
 
     this.owner.register(

--- a/tests/unit/dom-event-listeners-test.js
+++ b/tests/unit/dom-event-listeners-test.js
@@ -3,13 +3,13 @@ import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, triggerEvent } from '@ember/test-helpers';
 import {
   runDisposables,
   addEventListener,
-  removeEventListener,
+  removeEventListener
 } from 'ember-lifeline';
 import { PASSIVE_SUPPORTED } from 'ember-lifeline/dom-event-listeners';
 
@@ -32,7 +32,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
           this._super(...arguments);
 
           runDisposables(this);
-        },
+        }
       })
     );
 
@@ -44,12 +44,12 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
   [
     {
       testName: 'addEventListener(_,_,_,undefined)',
-      testedOptions: undefined,
+      testedOptions: undefined
     },
     {
       testName: 'addEventListener(_,_,_,{passive:false})',
-      testedOptions: { passive: false },
-    },
+      testedOptions: { passive: false }
+    }
   ].forEach(({ testName, testedOptions }) => {
     test(`${testName} adds event listener to child element`, async function(assert) {
       assert.expect(4);
@@ -119,7 +119,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
 
       let delta = {};
       await triggerEvent(component.element.firstChild, 'drag', {
-        details: { delta },
+        details: { delta }
       });
 
       assert.equal(calls, 1, 'callback was called');
@@ -231,7 +231,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
             this._super(...arguments);
 
             runDisposables(this);
-          },
+          }
         })
       );
       this.owner.register(
@@ -245,7 +245,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
             this._super(...arguments);
 
             runDisposables(this);
-          },
+          }
         })
       );
 
@@ -290,7 +290,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
             this._super(...arguments);
 
             runDisposables(this);
-          },
+          }
         })
       );
       this.owner.register(
@@ -304,7 +304,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
             this._super(...arguments);
 
             runDisposables(this);
-          },
+          }
         })
       );
 
@@ -377,7 +377,7 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
             runDisposables(this);
 
             this._super(...arguments);
-          },
+          }
         })
       );
 
@@ -454,37 +454,39 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
     );
 
     await triggerEvent(component.element.firstChild.firstChild, 'click', {
-      bubbles: true,
+      bubbles: true
     });
 
     assert.equal(outerCalls, 0, 'outer callback never fires');
     assert.equal(innerCalls, 1, 'inner callback fires');
   });
 
-  (PASSIVE_SUPPORTED ? test : skip)('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
-    assert.expect(2);
+  if (PASSIVE_SUPPORTED) {
+    test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
+      assert.expect(2);
 
-    this.owner.register(
-      'template:components/under-test',
-      hbs`<span class="foo"></span>`
-    );
-    await render(hbs`{{under-test}}`);
-    let component = this.componentInstance;
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      await render(hbs`{{under-test}}`);
+      let component = this.componentInstance;
 
-    let calls = 0;
-    let listener = () => {
-      calls++;
-    };
-    let element = find('.foo');
+      let calls = 0;
+      let listener = () => {
+        calls++;
+      };
+      let element = find('.foo');
 
-    addEventListener(component, element, 'click', listener, { once: true });
+      addEventListener(component, element, 'click', listener, { once: true });
 
-    await triggerEvent(element, 'click');
-    assert.equal(calls, 1, 'callback was called once');
+      await triggerEvent(element, 'click');
+      assert.equal(calls, 1, 'callback was called once');
 
-    await triggerEvent(element, 'click');
-    assert.equal(calls, 1, 'callback was called once');
-  });
+      await triggerEvent(element, 'click');
+      assert.equal(calls, 1, 'callback was called once');
+    });
+  }
 
   test('addEventListener to window', async function(assert) {
     assert.expect(1);
@@ -521,11 +523,19 @@ module('ember-lifeline/dom-event-listeners', function(hooks) {
     for (let i = 1; i <= iterations; i++) {
       addEventListener(component, window, 'click', listener);
       await triggerEvent(window, 'click');
-      assert.equal(calls, i, `callback was called after adding, iteration ${i}`);
+      assert.equal(
+        calls,
+        i,
+        `callback was called after adding, iteration ${i}`
+      );
 
       runDisposables(component);
       await triggerEvent(window, 'click');
-      assert.equal(calls, i, `callback was not called after calling runDisposables, iteration ${i}`);
+      assert.equal(
+        calls,
+        i,
+        `callback was not called after calling runDisposables, iteration ${i}`
+      );
     }
   });
 });

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -3,7 +3,7 @@ import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, triggerEvent } from '@ember/test-helpers';
 import { ContextBoundEventListenersMixin } from 'ember-lifeline';
@@ -22,7 +22,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         init() {
           this._super(...arguments);
           testContext.componentInstance = this;
-        },
+        }
       })
     );
 
@@ -34,12 +34,12 @@ module('ember-lifeline/mixins/dom', function(hooks) {
   [
     {
       testName: 'addEventListener(_,_,_,undefined)',
-      testedOptions: undefined,
+      testedOptions: undefined
     },
     {
       testName: 'addEventListener(_,_,_,{passive:false})',
-      testedOptions: { passive: false },
-    },
+      testedOptions: { passive: false }
+    }
   ].forEach(({ testName, testedOptions }) => {
     test(`${testName} adds event listener to child element`, async function(assert) {
       assert.expect(4);
@@ -141,7 +141,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
 
       let delta = {};
       await triggerEvent(component.element.firstChild, 'drag', {
-        details: { delta },
+        details: { delta }
       });
 
       assert.equal(calls, 1, 'callback was called');
@@ -284,7 +284,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
           init() {
             this._super(...arguments);
             testContext.subjectA = this;
-          },
+          }
         })
       );
       this.owner.register(
@@ -293,7 +293,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
           init() {
             this._super(...arguments);
             testContext.subjectB = this;
-          },
+          }
         })
       );
 
@@ -333,7 +333,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
           init() {
             this._super(...arguments);
             testContext.subjectA = this;
-          },
+          }
         })
       );
       this.owner.register(
@@ -342,7 +342,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
           init() {
             this._super(...arguments);
             testContext.subjectB = this;
-          },
+          }
         })
       );
 
@@ -559,35 +559,37 @@ module('ember-lifeline/mixins/dom', function(hooks) {
     );
 
     await triggerEvent(component.element.firstChild.firstChild, 'click', {
-      bubbles: true,
+      bubbles: true
     });
 
     assert.equal(outerCalls, 0, 'outer callback never fires');
     assert.equal(innerCalls, 1, 'inner callback fires');
   });
 
-  (PASSIVE_SUPPORTED ? test : skip)('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
-    assert.expect(2);
+  if (PASSIVE_SUPPORTED) {
+    test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
+      assert.expect(2);
 
-    this.owner.register(
-      'template:components/under-test',
-      hbs`<span class="foo"></span>`
-    );
-    await render(hbs`{{under-test}}`);
-    let component = this.componentInstance;
+      this.owner.register(
+        'template:components/under-test',
+        hbs`<span class="foo"></span>`
+      );
+      await render(hbs`{{under-test}}`);
+      let component = this.componentInstance;
 
-    let calls = 0;
-    let listener = () => {
-      calls++;
-    };
-    let element = find('.foo');
+      let calls = 0;
+      let listener = () => {
+        calls++;
+      };
+      let element = find('.foo');
 
-    component.addEventListener('.foo', 'click', listener, { once: true });
+      component.addEventListener('.foo', 'click', listener, { once: true });
 
-    await triggerEvent(element, 'click');
-    assert.equal(calls, 1, 'callback was called once');
+      await triggerEvent(element, 'click');
+      assert.equal(calls, 1, 'callback was called once');
 
-    await triggerEvent(element, 'click');
-    assert.equal(calls, 1, 'callback was called once');
-  });
+      await triggerEvent(element, 'click');
+      assert.equal(calls, 1, 'callback was called once');
+    });
+  }
 });

--- a/tests/unit/mixins/dom-test.js
+++ b/tests/unit/mixins/dom-test.js
@@ -3,10 +3,11 @@ import { run } from '@ember/runloop';
 import Component from '@ember/component';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find, triggerEvent } from '@ember/test-helpers';
 import { ContextBoundEventListenersMixin } from 'ember-lifeline';
+import { PASSIVE_SUPPORTED } from 'ember-lifeline/dom-event-listeners';
 
 module('ember-lifeline/mixins/dom', function(hooks) {
   setupRenderingTest(hooks);
@@ -65,7 +66,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      component.element.firstChild.dispatchEvent(new Event('click'));
+      await triggerEvent(component.element.firstChild, 'click');
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -101,7 +102,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      component.element.dispatchEvent(new Event('click'));
+      await triggerEvent(component.element, 'click');
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -396,7 +397,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      window.dispatchEvent(new Event('click'));
+      await triggerEvent(window, 'click');
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -426,7 +427,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
         testedOptions
       );
 
-      component.element.firstChild.dispatchEvent(new Event('click'));
+      await triggerEvent(component.element.firstChild, 'click');
 
       assert.equal(calls, 1, 'callback was called');
       assert.ok(hadRunloop, 'callback was called in runloop');
@@ -565,7 +566,7 @@ module('ember-lifeline/mixins/dom', function(hooks) {
     assert.equal(innerCalls, 1, 'inner callback fires');
   });
 
-  test('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
+  (PASSIVE_SUPPORTED ? test : skip)('addEventListener(_,_,{once: true}) is only called once', async function(assert) {
     assert.expect(2);
 
     this.owner.register(

--- a/tests/unit/utils/disposable-test.js
+++ b/tests/unit/utils/disposable-test.js
@@ -25,8 +25,9 @@ module('ember-lifeline/utils/disposable', function(hooks) {
   hooks.afterEach(function(assert) {
     run(this.obj, 'destroy');
 
-    let retainedObjects = [...this.registeredDisposables.keys()].map(o =>
-      o.toString()
+    let retainedObjects = [];
+    this.registeredDisposables.forEach((v, k) =>
+      retainedObjects.push(k.toString())
     );
 
     assert.deepEqual(

--- a/vendor/fix-promise.js
+++ b/vendor/fix-promise.js
@@ -1,0 +1,2 @@
+// https://github.com/babel/ember-cli-babel/issues/250
+self.Promise = self.Promise || Ember.RSVP.Promise;


### PR DESCRIPTION
Fixes #266.

So the only actual incompatibility was the incorrect usage of `Map` in `debounce-task.ts`. This should also be fixed by merging #248, but I'd rather get this PR in first and then rebase #248.

The reason the other test were failing was the usage of `EventTarget#dispatchEvent`, which is not supported in IE11. I've updated it to use `triggerEvent` from `@ember/test-helpers` instead. I also needed to conditionally skip the `{ once: true }` tests, since IE11 does not support it.

I would like to submit another PR which optionally polyfills this feature in IE11.