### PR TITLE
Fixing compile error with more strict type

### DIFF
--- a/addon/run-task.ts
+++ b/addon/run-task.ts
@@ -185,7 +185,7 @@ export function scheduleTask(
    */
 export function throttleTask(
   obj: IDestroyable,
-  taskName: string,
+  taskName: any,
   ...throttleArgs: any[]
 ): EmberRunTimer {
   assert(

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "^3.0.1"
   },
   "resolutions": {
-    "@types/ember__object": "~3.0.5",
+    "@types/ember__object": "~3.0.6",
     "@types/ember__component": "~3.0.4",
     "@types/ember__routing": "~3.0.6",
     "@types/ember__error": "~3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -728,11 +728,12 @@
   resolved "https://registry.yarnpkg.com/@types/ember__error/-/ember__error-3.0.2.tgz#a30c0e51215feaaa7a32e341c5a04bd601a01d1b"
   integrity sha512-U1IsKAfoqgNTAQ7rojbAmF8ynQaovfHP9Kff1lCB1A1FLq+vtQ81CzaiEHgWWAlPfbqrFtBIYD0rwehEQ1ofRg==
 
-"@types/ember__object@*", "@types/ember__object@~3.0.5":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/ember__object/-/ember__object-3.0.5.tgz#c4957cad68fffdd0959c6ca0d3469df8878b750c"
-  integrity sha512-0sgaktxsu86OqRNOe9lxLhqWnGGk+gNM+iuAbi7BKc5OZQHlOtAGPgHv7hUozWCW5cVK/3hMbr3ciD/vu25xsg==
+"@types/ember__object@*", "@types/ember__object@~3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/ember__object/-/ember__object-3.0.6.tgz#980822abe397ae16cce5dba51688aa0e0e12b39a"
+  integrity sha512-Kx2aKbbjF66k3+owaXQ5HDzn9+yIkg37neuN88sKcZdmHZA1g7xJq6fZliJMp3fX3pA5nbRYVM6Jt0OeBWjGFw==
   dependencies:
+    "@types/ember__object" "*"
     "@types/rsvp" "*"
 
 "@types/ember__polyfills@*":


### PR DESCRIPTION
Fixes issue with @types/ember__object by bumping to 3.0.6.
Fixes compile issue with `taskName` param in `throttleTask`.