### PR TITLE
Narrow dom types

### DIFF
--- a/API.md
+++ b/API.md
@@ -75,7 +75,7 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to register the task for
+- `destroyable` **IDestroyable** the instance to register the task for
 - `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
   which is run at the provided time specified
@@ -146,7 +146,7 @@ test('foo-bar watches things', async function(assert) {
 
 #### Parameters
 
-- `obj` **IDestroyable** the entangled object that was provided with the original \*Task call
+- `destroyable` **IDestroyable** the entangled object that was provided with the original \*Task call
 - `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
   which is run at the provided time specified
@@ -197,7 +197,7 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to register the task for
+- `destroyable` **IDestroyable** the instance to register the task for
 - `queueName` **[String][37]** the queue to schedule the task into
 - `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
@@ -236,7 +236,7 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to register the task for
+- `destroyable` **IDestroyable** the instance to register the task for
 - `name` **[String][37]** the name of the task to debounce
 - `debounceArgs` **...any** arguments to pass to the debounced method
 - `spacing` **[Number][38]** the amount of time to wait before calling the method (in milliseconds)
@@ -272,7 +272,7 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to register the task for
+- `destroyable` **IDestroyable** the instance to register the task for
 - `taskName` **[String][37]** the name of the task to throttle
 - `throttleArgs` **...any?** arguments to pass to the throttled method
 - `spacing` **[Number][38]** the time in the future to run the task
@@ -282,14 +282,14 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj`
+- `destroyable`
 - `cancelId`
 
 ### cancelPoll
 
 #### Parameters
 
-- `obj`
+- `destroyable`
 - `_token`
 
 ### cancelDebounce
@@ -325,7 +325,7 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to register the task for
+- `destroyable` **IDestroyable** the instance to register the task for
 - `methodName` **[String][37]** the name of the debounced method to cancel
 
 ## DOM event handler entanglement
@@ -370,7 +370,7 @@ export default Service.extend({
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to attach the listener for
+- `destroyable` **IDestroyable** the instance to attach the listener for
 - `target` **EventTarget** the EventTarget, e.g. DOM element or `window`
 - `eventName` **[String][37]** the event name to listen for
 - `callback` **[Function][36]** the callback to run for that event
@@ -383,7 +383,7 @@ lifeline's DOM entanglement tracking.
 
 #### Parameters
 
-- `obj` **IDestroyable** the instance to remove the listener for
+- `destroyable` **IDestroyable** the instance to remove the listener for
 - `target` **EventTarget** the EventTarget, e.g. DOM element or `window`
 - `eventName` **[String][37]** the event name to listen for
 - `callback` **[Function][36]** the callback to run for that event

--- a/API.md
+++ b/API.md
@@ -75,12 +75,12 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to register the task for
-- `taskOrName` **([Function][37] \| [String][38])** a function representing the task, or string
+- `obj` **IDestroyable** the instance to register the task for
+- `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
   which is run at the provided time specified
   by timeout
-- `timeout` **[Number][39]** the time in the future to run the task (optional, default `0`)
+- `timeout` **[Number][38]** the time in the future to run the task (optional, default `0`)
 
 ### pollTask
 
@@ -146,12 +146,12 @@ test('foo-bar watches things', async function(assert) {
 
 #### Parameters
 
-- `obj` **[Object][36]** the entangled object that was provided with the original \*Task call
-- `taskOrName` **([Function][37] \| [String][38])** a function representing the task, or string
+- `obj` **IDestroyable** the entangled object that was provided with the original \*Task call
+- `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
   which is run at the provided time specified
   by timeout
-- `token` **Token** the Token for the pollTask
+- `token` **Token** the Token for the pollTask, either a String or Number
 
 ### pollTaskFor
 
@@ -197,9 +197,9 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to register the task for
-- `queueName` **[String][38]** the queue to schedule the task into
-- `taskOrName` **([Function][37] \| [String][38])** a function representing the task, or string
+- `obj` **IDestroyable** the instance to register the task for
+- `queueName` **[String][37]** the queue to schedule the task into
+- `taskOrName` **([Function][36] \| [String][37])** a function representing the task, or string
   specifying a property representing the task,
   which is run at the provided time specified
   by timeout
@@ -236,11 +236,11 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to register the task for
-- `name` **[String][38]** the name of the task to debounce
+- `obj` **IDestroyable** the instance to register the task for
+- `name` **[String][37]** the name of the task to debounce
 - `debounceArgs` **...any** arguments to pass to the debounced method
-- `spacing` **[Number][39]** the amount of time to wait before calling the method (in milliseconds)
-- `immediate` **[Boolean][40]?** Trigger the function on the leading instead of the trailing edge of the wait interval. Defaults to false.
+- `spacing` **[Number][38]** the amount of time to wait before calling the method (in milliseconds)
+- `immediate` **[Boolean][39]?** Trigger the function on the leading instead of the trailing edge of the wait interval. Defaults to false.
 
 ### throttleTask
 
@@ -272,11 +272,11 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to register the task for
-- `taskName` **[String][38]** the name of the task to throttle
+- `obj` **IDestroyable** the instance to register the task for
+- `taskName` **[String][37]** the name of the task to throttle
 - `throttleArgs` **...any?** arguments to pass to the throttled method
-- `spacing` **[Number][39]** the time in the future to run the task
-- `immediate` **[Boolean][40]?** Trigger the function on the leading instead of the trailing edge of the wait interval. Defaults to true.
+- `spacing` **[Number][38]** the time in the future to run the task
+- `immediate` **[Boolean][39]?** Trigger the function on the leading instead of the trailing edge of the wait interval. Defaults to true.
 
 ### cancelTask
 
@@ -325,8 +325,8 @@ export default Component.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to register the task for
-- `methodName` **[String][38]** the name of the debounced method to cancel
+- `obj` **IDestroyable** the instance to register the task for
+- `methodName` **[String][37]** the name of the debounced method to cancel
 
 ## DOM event handler entanglement
 
@@ -370,20 +370,24 @@ export default Service.extend({
 
 #### Parameters
 
-- `obj` **[Object][36]** the instance to attach the listener for
+- `obj` **IDestroyable** the instance to attach the listener for
 - `target` **EventTarget** the EventTarget, e.g. DOM element or `window`
-- `eventName` **[String][38]** the event name to listen for
-- `callback` **[Function][37]** the callback to run for that event
+- `eventName` **[String][37]** the event name to listen for
+- `callback` **[Function][36]** the callback to run for that event
+- `options` **any** additional options provided to the browser's `addEventListener`
 
 ### removeEventListener
 
+Removes an event listener explicitly from the target, also removing it from
+lifeline's DOM entanglement tracking.
+
 #### Parameters
 
-- `obj` **[Object][36]** the instance to remove the listener for
+- `obj` **IDestroyable** the instance to remove the listener for
 - `target` **EventTarget** the EventTarget, e.g. DOM element or `window`
-- `eventName` **[String][38]** the event name to listen for
-- `callback` **[Function][37]** the callback to run for that event
-- `options`
+- `eventName` **[String][37]** the event name to listen for
+- `callback` **[Function][36]** the callback to run for that event
+- `options` **any** additional options provided to the browser's `removeEventListener`
 
 ## Disposables
 
@@ -464,8 +468,7 @@ included into all `Ember.View`, `Ember.Component`, and `Ember.Service` instances
 [33]: #disposablemixin
 [34]: #contextboundeventlistenersmixin
 [35]: #contextboundtasksmixin
-[36]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
-[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
-[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
-[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
-[40]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[36]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function
+[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[38]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[39]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean

--- a/addon/dom-event-listeners.ts
+++ b/addon/dom-event-listeners.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { bind } from '@ember/runloop';
 import { registerDisposable } from './utils/disposable';
-import { IMap } from './interfaces';
+import { IMap, IDestroyable } from './interfaces';
 
 /**
  * A map of instances/listeners that allows us to
@@ -10,7 +10,10 @@ import { IMap } from './interfaces';
  * @private
  *
  */
-const eventListeners: IMap<Object, Array<Object>> = new WeakMap<Object, any>();
+const eventListeners: IMap<IDestroyable, Array<Object>> = new WeakMap<
+  IDestroyable,
+  any
+>();
 
 export const PASSIVE_SUPPORTED: boolean = (() => {
   let ret: boolean = false;
@@ -79,19 +82,20 @@ enum ListenerItemPosition {
    });
    ```
 
+   @public
    @method addEventListener
-   @param { Object } obj the instance to attach the listener for
+   @param { IDestroyable } obj the instance to attach the listener for
    @param { EventTarget } target the EventTarget, e.g. DOM element or `window`
    @param { String } eventName the event name to listen for
    @param { Function } callback the callback to run for that event
-   @public
+   @param { any } options additional options provided to the browser's `addEventListener`
    */
-export function addEventListener<Target>(
-  obj: Target,
+export function addEventListener<T extends IDestroyable>(
+  obj: T,
   target: EventTarget,
   eventName: string,
-  callback: RunMethod<Target>,
-  options: any
+  callback: RunMethod<T>,
+  options?: any
 ): void {
   assertArguments(target, eventName, callback);
 
@@ -117,18 +121,22 @@ export function addEventListener<Target>(
 }
 
 /**
-   @param { Object } obj the instance to remove the listener for
+   Removes an event listener explicitly from the target, also removing it from
+   lifeline's DOM entanglement tracking.
+
+   @public
+   @param { IDestroyable } obj the instance to remove the listener for
    @param { EventTarget } target the EventTarget, e.g. DOM element or `window`
    @param { String } eventName the event name to listen for
    @param { Function } callback the callback to run for that event
-   @public
+   @param { any } options additional options provided to the browser's `removeEventListener`
    */
-export function removeEventListener<Target>(
-  obj: Target,
+export function removeEventListener<T extends IDestroyable>(
+  obj: T,
   target: EventTarget,
   eventName: string,
-  callback: RunMethod<Target>,
-  options: any
+  callback: RunMethod<T>,
+  options?: any
 ): void {
   assertArguments(target, eventName, callback);
 

--- a/addon/dom-event-listeners.ts
+++ b/addon/dom-event-listeners.ts
@@ -84,14 +84,14 @@ enum ListenerItemPosition {
 
    @public
    @method addEventListener
-   @param { IDestroyable } obj the instance to attach the listener for
+   @param { IDestroyable } destroyable the instance to attach the listener for
    @param { EventTarget } target the EventTarget, e.g. DOM element or `window`
    @param { String } eventName the event name to listen for
    @param { Function } callback the callback to run for that event
    @param { any } options additional options provided to the browser's `addEventListener`
    */
 export function addEventListener<T extends IDestroyable>(
-  obj: T,
+  destroyable: T,
   target: EventTarget,
   eventName: string,
   callback: RunMethod<T>,
@@ -99,17 +99,23 @@ export function addEventListener<T extends IDestroyable>(
 ): void {
   assertArguments(target, eventName, callback);
 
-  let _callback: EventListenerOrEventListenerObject = bind(obj, callback);
-  let listeners: Array<Object> = eventListeners.get(obj);
+  let _callback: EventListenerOrEventListenerObject = bind(
+    destroyable,
+    callback
+  );
+  let listeners: Array<Object> = eventListeners.get(destroyable);
 
   if (listeners === undefined) {
     listeners = [];
-    eventListeners.set(obj, listeners);
+    eventListeners.set(destroyable, listeners);
   }
 
   // Register a disposable every time we go from zero to one.
   if (listeners.length === 0) {
-    registerDisposable(obj as any, getEventListenersDisposable(listeners));
+    registerDisposable(
+      destroyable as any,
+      getEventListenersDisposable(listeners)
+    );
   }
 
   if (!PASSIVE_SUPPORTED) {
@@ -125,14 +131,14 @@ export function addEventListener<T extends IDestroyable>(
    lifeline's DOM entanglement tracking.
 
    @public
-   @param { IDestroyable } obj the instance to remove the listener for
+   @param { IDestroyable } destroyable the instance to remove the listener for
    @param { EventTarget } target the EventTarget, e.g. DOM element or `window`
    @param { String } eventName the event name to listen for
    @param { Function } callback the callback to run for that event
    @param { any } options additional options provided to the browser's `removeEventListener`
    */
 export function removeEventListener<T extends IDestroyable>(
-  obj: T,
+  destroyable: T,
   target: EventTarget,
   eventName: string,
   callback: RunMethod<T>,
@@ -140,7 +146,7 @@ export function removeEventListener<T extends IDestroyable>(
 ): void {
   assertArguments(target, eventName, callback);
 
-  let listeners: Array<Object> = eventListeners.get(obj);
+  let listeners: Array<Object> = eventListeners.get(destroyable);
 
   if (listeners === undefined || listeners.length === 0) {
     return;


### PR DESCRIPTION
Further cleans up typing within the DOM APIs. Additionally renames `obj` to `destroyable` in all places.