### PR TITLE
Implements early return when *Task functions called on destroyed objects

### DIFF
--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -1,6 +1,6 @@
 import { assert } from '@ember/debug';
 import { cancel, debounce } from '@ember/runloop';
-import { IDestroyable, IMap } from './interfaces';
+import { IDestroyable, IMap, Timer } from './types';
 import { registerDisposable } from './utils/disposable';
 
 interface PendingDebounce {
@@ -69,10 +69,10 @@ export function debounceTask(
     `Called \`destroyable.debounceTask('${name}', ...)\` where 'destroyable.${name}' is not a function.`,
     typeof destroyable[name] === 'function'
   );
-  assert(
-    `Called \`debounceTask\` on destroyed object: ${destroyable}.`,
-    !destroyable.isDestroyed
-  );
+
+  if (destroyable.isDestroying) {
+    return undefined;
+  }
 
   const lastArgument = debounceArgs[debounceArgs.length - 1];
   const spacing =

--- a/addon/debounce-task.ts
+++ b/addon/debounce-task.ts
@@ -71,7 +71,7 @@ export function debounceTask(
   );
 
   if (destroyable.isDestroying) {
-    return undefined;
+    return;
   }
 
   const lastArgument = debounceArgs[debounceArgs.length - 1];

--- a/addon/dom-event-listeners.ts
+++ b/addon/dom-event-listeners.ts
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import { bind } from '@ember/runloop';
 import { registerDisposable } from './utils/disposable';
-import { IMap, IDestroyable } from './interfaces';
+import { IMap, IDestroyable } from './types';
 
 /**
  * A map of instances/listeners that allows us to

--- a/addon/mixins/dom.ts
+++ b/addon/mixins/dom.ts
@@ -2,7 +2,7 @@ import Mixin from '@ember/object/mixin';
 import { assert } from '@ember/debug';
 import { addEventListener, removeEventListener } from '../dom-event-listeners';
 import { runDisposables } from '../utils/disposable';
-import { IDestroyable } from '../interfaces';
+import { IDestroyable } from '../types';
 
 type MaybeIsComponent = IDestroyable & {
   isComponent?: boolean;

--- a/addon/poll-task.ts
+++ b/addon/poll-task.ts
@@ -4,7 +4,7 @@ import { assert } from '@ember/debug';
 import { deprecate } from '@ember/application/deprecations';
 import getTask from './utils/get-task';
 import { registerDisposable } from './utils/disposable';
-import { IMap, TaskOrName, IDestroyable } from './interfaces';
+import { IMap, TaskOrName, IDestroyable } from './types';
 
 type Token = string | number;
 

--- a/addon/run-task.ts
+++ b/addon/run-task.ts
@@ -266,12 +266,16 @@ export function throttleTask(
    @param { Number } cancelId the id returned from the *Task call
    @public
    */
-export function cancelTask(cancelId: EmberRunTimer);
-export function cancelTask(destroyable: IDestroyable, cancelId: EmberRunTimer);
+export function cancelTask(cancelId: Timer);
+export function cancelTask(destroyable: IDestroyable, cancelId: Timer);
 export function cancelTask(
-  destroyable: IDestroyable | EmberRunTimer,
+  destroyable: IDestroyable | Timer,
   cancelId?: any
 ): void | undefined {
+  if (cancelId === NULL_TIMER_ID) {
+    return;
+  }
+
   if (typeof cancelId === 'undefined') {
     deprecate(
       'ember-lifeline cancelTask called without an object. New syntax is cancelTask(destroyable, cancelId) and avoids a memory leak.',

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -11,3 +11,5 @@ export interface IDestroyable {
 }
 
 export type TaskOrName = Function | string;
+
+export type Timer = EmberRunTimer | number;

--- a/addon/utils/disposable.ts
+++ b/addon/utils/disposable.ts
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import { IMap, IDestroyable } from '../interfaces';
+import { IMap, IDestroyable } from '../types';
 
 /**
  * A map of instances/array of disposables. Only exported for

--- a/addon/utils/get-task.ts
+++ b/addon/utils/get-task.ts
@@ -1,4 +1,4 @@
-import { TaskOrName, IDestroyable } from '../interfaces';
+import { TaskOrName, IDestroyable } from '../types';
 
 export default function getTask(
   obj: IDestroyable,


### PR DESCRIPTION
Implements early returning on `runTask`, `scheduleTask`, and `throttleTask` if the object is destroyed.

Fixes #130 + #168.