### PR TITLE
Removing deprecation warnings targeted for 4.0.0

### DIFF
--- a/addon/mixins/run.ts
+++ b/addon/mixins/run.ts
@@ -3,7 +3,7 @@ import { deprecate } from '@ember/debug';
 import { runTask, scheduleTask, throttleTask, cancelTask } from '../run-task';
 import { pollTask, cancelPoll, Token } from '../poll-task';
 import { debounceTask, cancelDebounce } from '../debounce-task';
-import { TaskOrName, EmberRunQueues } from '../types';
+import { TaskOrName, EmberRunQueues, EmberRunTimer } from '../types';
 
 /**
  * ContextBoundTasksMixin provides a mechanism to run tasks (ala `setTimeout` or
@@ -84,11 +84,11 @@ export default Mixin.create({
    * ```
    *
    * @method cancelTask
-   * @param { Number } cancelId the id returned from the runTask or scheduleTask call
+   * @param { EmberRunTimer } cancelId the id returned from the runTask or scheduleTask call
    * @public
    */
-  cancelTask(cancelId: number) {
-    cancelTask(cancelId);
+  cancelTask(cancelId: EmberRunTimer) {
+    cancelTask(this, cancelId);
   },
 
   /**
@@ -247,11 +247,11 @@ export default Mixin.create({
    * ```
    *
    * @method cancelThrottle
-   * @param { Number } cancelId the id returned from the throttleTask call
+   * @param { EmberRunTimer } cancelId the id returned from the throttleTask call
    * @public
    */
-  cancelThrottle(cancelId: number) {
-    cancelTask(cancelId);
+  cancelThrottle(cancelId: EmberRunTimer) {
+    cancelTask(this, cancelId);
   },
 
   /**
@@ -348,10 +348,10 @@ export default Mixin.create({
    * ```
    *
    * @method cancelPoll
-   * @param { String } token the token for the pollTask to be cleared
+   * @param { Token } token the token for the pollTask to be cleared
    * @public
    */
   cancelPoll(token: Token) {
-    cancelPoll(token);
+    cancelPoll(this, token);
   },
 });

--- a/addon/poll-task.ts
+++ b/addon/poll-task.ts
@@ -1,6 +1,4 @@
 import Ember from 'ember';
-
-import { deprecate } from '@ember/application/deprecations';
 import getTask from './utils/get-task';
 import { IMap, TaskOrName, IDestroyable } from './types';
 import { registerDestructor } from '@ember/destroyable';
@@ -199,34 +197,18 @@ export function pollTask(
  * @param { Token } token the Token for the pollTask to be cleared, either a string or number
  * @public
  */
-export function cancelPoll(token: Token): void | undefined;
 export function cancelPoll(
   destroyable: IDestroyable,
   token: Token
-): void | undefined;
-export function cancelPoll(
-  destroyable: IDestroyable | Token,
-  token?: Token
 ): void | undefined {
   let pollToken: Token;
-  if (typeof destroyable === 'number' || typeof destroyable === 'string') {
-    deprecate(
-      'ember-lifeline cancelPoll called without an object. New syntax is cancelPoll(destroyable, cancelId) and avoids a memory leak.',
-      true,
-      {
-        id: 'ember-lifeline-cancel-poll-without-object',
-        until: '4.0.0',
-      }
-    );
-    pollToken = destroyable;
-  } else {
-    let pollers: Set<Token> = registeredPollers.get(destroyable);
-    pollToken = token as Token;
+  let pollers: Set<Token> = registeredPollers.get(destroyable);
+  pollToken = token as Token;
 
-    if (pollers !== undefined) {
-      pollers.delete(pollToken);
-    }
+  if (pollers !== undefined) {
+    pollers.delete(pollToken);
   }
+
   delete queuedPollTasks[pollToken];
 }
 

--- a/addon/run-task.ts
+++ b/addon/run-task.ts
@@ -1,4 +1,3 @@
-import { deprecate } from '@ember/application/deprecations';
 import { assert } from '@ember/debug';
 import { cancel, later, schedule, throttle } from '@ember/runloop';
 import {
@@ -272,33 +271,13 @@ export function throttleTask(
  * @param { Number } cancelId the id returned from the *Task call
  * @public
  */
-export function cancelTask(cancelId: Timer): void | undefined;
 export function cancelTask(
   destroyable: IDestroyable,
-  cancelId: Timer
-): void | undefined;
-export function cancelTask(
-  destroyable: IDestroyable | Timer,
-  cancelId?: any
+  cancelId: EmberRunTimer
 ): void | undefined {
-  if (cancelId === NULL_TIMER_ID) {
-    return;
-  }
+  let timers: Set<EmberRunTimer> = getTimers(<IDestroyable>destroyable);
 
-  if (typeof cancelId === 'undefined') {
-    deprecate(
-      'ember-lifeline cancelTask called without an object. New syntax is cancelTask(destroyable, cancelId) and avoids a memory leak.',
-      true,
-      {
-        id: 'ember-lifeline-cancel-task-without-object',
-        until: '4.0.0',
-      }
-    );
-    cancelId = destroyable;
-  } else {
-    let timers: Set<EmberRunTimer> = getTimers(<IDestroyable>destroyable);
-    timers.delete(cancelId);
-  }
+  timers.delete(cancelId);
   cancel(cancelId);
 }
 

--- a/tests/unit/run-task-test.js
+++ b/tests/unit/run-task-test.js
@@ -130,7 +130,7 @@ module('ember-lifeline/run-task', function (hooks) {
       5
     );
 
-    cancelTask(cancelId);
+    cancelTask(this.obj, cancelId);
 
     window.setTimeout(() => {
       assert.notOk(hasRun, 'callback should have been canceled previously');
@@ -229,7 +229,7 @@ module('ember-lifeline/run-task', function (hooks) {
         hasRun = true;
       });
 
-      cancelTask(timer);
+      cancelTask(this.obj, timer);
     });
 
     assert.notOk(hasRun, 'callback should have been canceled previously');


### PR DESCRIPTION
Removing deprecations that were intended to be removed in 4.0.0 (oops!). 

I marked this as breaking due to the change in the mixin parameter types for the cancel calls.