### PR TITLE
Updates jsdoc strings to represent Octane components

### DIFF
--- a/packages/ember-lifeline/src/cancel-task.ts
+++ b/packages/ember-lifeline/src/cancel-task.ts
@@ -58,11 +58,11 @@ export function getTimers(destroyable: IDestroyable): Set<EmberRunTimer> {
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { runTask, cancelTask } from 'ember-lifeline';
  *
- * export default Component.extend({
- *   didInsertElement() {
+ * export default CancelableComponent extends Component {
+ *   start() {
  *     this._cancelId = runTask(this, () => {
  *       console.log('This runs after 5 seconds if this component is still displayed');
  *     }, 5000)
@@ -71,7 +71,7 @@ export function getTimers(destroyable: IDestroyable): Set<EmberRunTimer> {
  *   disable() {
  *     cancelTask(this, this._cancelId);
  *   },
- * });
+ * }
  * ```
  *
  * @function cancelTask

--- a/packages/ember-lifeline/src/debounce-task.ts
+++ b/packages/ember-lifeline/src/debounce-task.ts
@@ -27,10 +27,10 @@ const registeredDebounces: IMap<
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { debounceTask } from 'ember-lifeline';
  *
- * export default Component.extend({
+ * export default LoggerComponent extends Component {
  *   logMe() {
  *     console.log('This will only run once every 300ms.');
  *   },
@@ -38,7 +38,7 @@ const registeredDebounces: IMap<
  *   click() {
  *     debounceTask(this, 'logMe', 300);
  *   },
- * });
+ * }
  * ```
  *
  * @function debounceTask
@@ -112,10 +112,10 @@ export function debounceTask(
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { debounceTask, cancelDebounce } from 'ember-lifeline';
  *
- * export default Component.extend({
+ * export default LoggerComponent extends Component {
  *   logMe() {
  *     console.log('This will only run once every 300ms.');
  *   },
@@ -127,7 +127,7 @@ export function debounceTask(
  *   disable() {
  *      cancelDebounce(this, 'logMe');
  *   },
- * });
+ * }
  * ```
  *
  * @function cancelDebounce

--- a/packages/ember-lifeline/src/poll-task.ts
+++ b/packages/ember-lifeline/src/poll-task.ts
@@ -77,9 +77,10 @@ export function getQueuedPollTasks(): Map<Token, () => void> {
  * Example:
  *
  * ```js
+ * import Component from '@glimmer/component';
  * import { pollTask, runTask } from 'ember-lifeline';
  *
- * export default Component.extend({
+ * export default PollingComponent extends Component {
  *   api: injectService(),
  *
  *   init() {
@@ -100,24 +101,22 @@ export function getQueuedPollTasks(): Map<Token, () => void> {
  * Test Example:
  *
  * ```js
- * import wait from 'ember-test-helpers/wait';
+ * import { settled } from '@ember/test-helpers';
  * import { pollTaskFor } from 'ember-lifeline';
  *
- * //...snip...
  *
  * test('foo-bar watches things', async function(assert) {
  *   await render(hbs`{{foo-bar}}`);
  *
- *   return wait()
- *     .then(() => {
- *       assert.equal(serverRequests, 1, 'called initially');
+ *   assert.equal(serverRequests, 1, 'called initially');
  *
- *       pollTaskFor(this._pollToken);
- *       return wait();
- *     })
- *     .then(() => {
- *       assert.equal(serverRequests, 2, 'called again');
- *     });
+ *   pollTaskFor(this._pollToken);
+ *
+ *   await settled();
+ *
+ *   assert.equal(serverRequests, 2, 'called again');
+ *
+ *   await settled();
  * });
  * ```
  *
@@ -172,10 +171,12 @@ export function pollTask(
  * Example:
  *
  * ```js
+ * import Component from '@glimmer/component';
+ * import { inject as service } from '@ember/service';
  * import { pollTask, runTask } from 'ember-lifeline';
  *
- * export default Component.extend({
- *   api: injectService(),
+ * export default AutoRefreshComponent extends Component {
+ *   @service api;
  *
  *   enableAutoRefresh() {
  *     this._pollToken = pollTask(this, (next) => {
@@ -189,7 +190,7 @@ export function pollTask(
  *   disableAutoRefresh() {
  *     cancelPoll(this, this._pollToken);
  *   },
- * });
+ * }
  * ```
  *
  * @method cancelPoll

--- a/packages/ember-lifeline/src/run-task.ts
+++ b/packages/ember-lifeline/src/run-task.ts
@@ -12,11 +12,11 @@ import { getTimers, NULL_TIMER_ID } from './cancel-task';
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { runTask } from 'ember-lifeline';
  *
- * export default Component.extend({
- *   didInsertElement() {
+ * export default RunComponent extends Component {
+ *   start() {
  *     runTask(this, () => {
  *       console.log('This runs after 5 seconds if this component is still displayed');
  *     }, 5000)

--- a/packages/ember-lifeline/src/schedule-task.ts
+++ b/packages/ember-lifeline/src/schedule-task.ts
@@ -18,13 +18,11 @@ import getTask from './utils/get-task';
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { scheduleTask } from 'ember-lifeline';
  *
- * export default Component.extend({
- *   init() {
- *     this._super(...arguments);
- *
+ * export default ScheduledComponent extends Component {
+ *   start() {
  *     scheduleTask(this, 'actions', () => {
  *       console.log('This runs at the end of the run loop (via the actions queue) if this component is still displayed');
  *     })

--- a/packages/ember-lifeline/src/throttle-task.ts
+++ b/packages/ember-lifeline/src/throttle-task.ts
@@ -11,10 +11,10 @@ import { EmberRunTimer, IDestroyable, Timer } from './types';
  * Example:
  *
  * ```js
- * import Component from 'ember-component';
+ * import Component from '@glimmer/component';
  * import { throttleTask } from 'ember-lifeline';
  *
- * export default Component.extend({
+ * export default LoggerComponent extends Component {
  *   logMe() {
  *     console.log('This will run once immediately, then only once every 300ms.');
  *   },


### PR DESCRIPTION
Removes old usages of `Component.extend` in favor of Glimmer components for jsdoc strings.