### PR TITLE
Created timer util that returns a scaled-down timer value in test environments.

### DIFF
--- a/addon/index.ts
+++ b/addon/index.ts
@@ -16,7 +16,7 @@ export {
 export { debounceTask, cancelDebounce } from './debounce-task';
 export { addEventListener, removeEventListener } from './dom-event-listeners';
 export { registerDisposable, runDisposables } from './utils/disposable';
-export { getTestAwareTimerVal } from './utils/timer';
+export { getTimeoutOrTestFallback } from './utils/timer';
 
 export { default as ContextBoundTasksMixin } from './mixins/run';
 export { default as ContextBoundEventListenersMixin } from './mixins/dom';

--- a/addon/index.ts
+++ b/addon/index.ts
@@ -16,6 +16,7 @@ export {
 export { debounceTask, cancelDebounce } from './debounce-task';
 export { addEventListener, removeEventListener } from './dom-event-listeners';
 export { registerDisposable, runDisposables } from './utils/disposable';
+export { getTestAwareTimerVal } from './utils/timer';
 
 export { default as ContextBoundTasksMixin } from './mixins/run';
 export { default as ContextBoundEventListenersMixin } from './mixins/dom';

--- a/addon/types/index.ts
+++ b/addon/types/index.ts
@@ -30,3 +30,15 @@ export type EmberRunQueues =
   | 'render'
   | 'afterRender'
   | 'destroy';
+
+export interface ITestTimeoutWithTimeout {
+  timeout: number;
+  scaling?: never;
+}
+export interface ITestTimeoutWithScaling {
+  timeout?: never;
+  scaling: number;
+}
+export type TestTimeoutOptions =
+  | ITestTimeoutWithTimeout
+  | ITestTimeoutWithScaling;

--- a/addon/utils/timer.ts
+++ b/addon/utils/timer.ts
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+/**
+ * @function getTestAwareTimerVal
+ * @param {number} timerVal The timer value that gets scaled down in case of the test environment.
+ * @param {number} [customTestTimerVal] The timer value that needs to be set in the test environment if passed
+ */
+export function getTestAwareTimerVal(
+  timerVal: number,
+  customTestTimerVal?: number
+): number {
+  if (Ember.testing) {
+    return customTestTimerVal !== undefined
+      ? customTestTimerVal
+      : timerVal / 100; // Reducing timer value by 100x in test environment
+  }
+  return timerVal;
+}

--- a/addon/utils/timer.ts
+++ b/addon/utils/timer.ts
@@ -1,18 +1,22 @@
 import Ember from 'ember';
+import { TestTimeoutOptions } from '../types';
 
 /**
- * @function getTestAwareTimerVal
- * @param {number} timerVal The timer value that gets scaled down in case of the test environment.
- * @param {number} [customTestTimerVal] The timer value that needs to be set in the test environment if passed
+ * @function getTimeoutOrTestFallback
+ * @param {number} timeoutVal The timeout value that gets scaled down in case of the test environment.
+ * @param {number} [customTestTimeout] The timeout value that needs to be set in the test environment if passed
  */
-export function getTestAwareTimerVal(
-  timerVal: number,
-  customTestTimerVal?: number
+export function getTimeoutOrTestFallback(
+  timeoutVal: number,
+  options?: TestTimeoutOptions
 ): number {
   if (Ember.testing) {
-    return customTestTimerVal !== undefined
-      ? customTestTimerVal
-      : timerVal / 100; // Reducing timer value by 100x in test environment
+    const customTestTimeout = options?.timeout;
+    const scaleDownFactor = options?.scaling ?? 100; // Reducing timer value by 100x in test environment by default
+
+    return customTestTimeout !== undefined
+      ? customTestTimeout
+      : timeoutVal / scaleDownFactor;
   }
-  return timerVal;
+  return timeoutVal;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-lifeline",
-  "version": "6.0.3",
+  "version": "6.0.2",
   "description": "Ember.js addon for lifecycle aware async tasks and DOM events.",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-lifeline",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Ember.js addon for lifecycle aware async tasks and DOM events.",
   "keywords": [
     "ember-addon"

--- a/tests/unit/utils/timer-test.js
+++ b/tests/unit/utils/timer-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { getTestAwareTimerVal } from 'ember-lifeline/utils/timer';
+
+module('ember-lifeline/utils/timer', function () {
+  test('getTestAwareTimerVal will scale down the timer value by 100x by default in the test environment', function (assert) {
+    assert.expect(3);
+
+    assert.equal(
+      getTestAwareTimerVal(100),
+      1,
+      'timer value has been scaled down'
+    );
+    assert.equal(
+      getTestAwareTimerVal(500),
+      5,
+      'timer value has been scaled down'
+    );
+    assert.equal(
+      getTestAwareTimerVal(3000),
+      30,
+      'timer value has been scaled down'
+    );
+  });
+
+  test('getTestAwareTimerVal will return the custom test timer value if passed in the test environment', function (assert) {
+    assert.expect(3);
+
+    assert.equal(
+      getTestAwareTimerVal(100, 2),
+      2,
+      'custom test timer value is returned'
+    );
+    assert.equal(
+      getTestAwareTimerVal(500, 3),
+      3,
+      'custom test timer value is returned'
+    );
+    assert.equal(
+      getTestAwareTimerVal(3000, 20),
+      20,
+      'custom test timer value is returned'
+    );
+  });
+});

--- a/tests/unit/utils/timer-test.js
+++ b/tests/unit/utils/timer-test.js
@@ -1,44 +1,64 @@
 import { module, test } from 'qunit';
-import { getTestAwareTimerVal } from 'ember-lifeline/utils/timer';
+import { getTimeoutOrTestFallback } from 'ember-lifeline/utils/timer';
 
 module('ember-lifeline/utils/timer', function () {
-  test('getTestAwareTimerVal will scale down the timer value by 100x by default in the test environment', function (assert) {
+  test('getTimeoutOrTestFallback will scale down the timer value by 100x by default in the test environment', function (assert) {
     assert.expect(3);
 
     assert.equal(
-      getTestAwareTimerVal(100),
+      getTimeoutOrTestFallback(100),
       1,
       'timer value has been scaled down'
     );
     assert.equal(
-      getTestAwareTimerVal(500),
+      getTimeoutOrTestFallback(500),
       5,
       'timer value has been scaled down'
     );
     assert.equal(
-      getTestAwareTimerVal(3000),
+      getTimeoutOrTestFallback(3000),
       30,
       'timer value has been scaled down'
     );
   });
 
-  test('getTestAwareTimerVal will return the custom test timer value if passed in the test environment', function (assert) {
+  test('getTimeoutOrTestFallback will return the custom test timer value  in the test environment if passed', function (assert) {
     assert.expect(3);
 
     assert.equal(
-      getTestAwareTimerVal(100, 2),
+      getTimeoutOrTestFallback(100, { timeout: 2 }),
       2,
       'custom test timer value is returned'
     );
     assert.equal(
-      getTestAwareTimerVal(500, 3),
+      getTimeoutOrTestFallback(500, { timeout: 3 }),
       3,
       'custom test timer value is returned'
     );
     assert.equal(
-      getTestAwareTimerVal(3000, 20),
+      getTimeoutOrTestFallback(3000, { timeout: 20 }),
       20,
       'custom test timer value is returned'
+    );
+  });
+
+  test('getTimeoutOrTestFallback will return the scaled down timeout value in the test environment if passed', function (assert) {
+    assert.expect(3);
+
+    assert.equal(
+      getTimeoutOrTestFallback(100, { scaling: 2 }),
+      50,
+      'scaled down timeout value is returned'
+    );
+    assert.equal(
+      getTimeoutOrTestFallback(300, { scaling: 3 }),
+      100,
+      'scaled down timeout value is returned'
+    );
+    assert.equal(
+      getTimeoutOrTestFallback(100, { scaling: 20 }),
+      5,
+      'scaled down timeout value is returned'
     );
   });
 });


### PR DESCRIPTION
## Summary
Created timer util that returns a scaled-down timer value in the test environments.

## Details
ember-lifeline methods such as `runTask`, `debounceTask` defer execution of the callback function passed to them by the amount of timer value that is passed to these functions. Under the hood, It uses ember runloop's methods which in turn will be delegated to `backburner`.

Since these tasks are delegated to the backburner, they fall under ember-aware async constructs. Due to this, the async ember test util `settled` (`click`, `render` etc., internally uses the `settled` method) will wait for all the pending async timer functions to be completed and then the test execution flow will proceed to the next line.

Let's say we are debouncing the task of making a request to API to fetch the typeahead results by 300ms. It means that the test will wait for at least 300ms to make an API call (which can be mocked using `pretender` or `ember-cli-mirage`). Ideally, in test environments, there is no need to wait as the necessary input will be added programmatically as opposed to the user typing manually (in which case it makes sense to defer by 300ms owing to the typing speed of a user)

Hence, I have added a util method to return a scaled-down version of the timer in the test environments. By default, it will scale down the timer value by 100x. If a second argument is passed, the second value will be returned in the test environment.
