### PR TITLE
Make cancelId optional in cancelTask

### DIFF
--- a/packages/ember-lifeline/package.json
+++ b/packages/ember-lifeline/package.json
@@ -53,6 +53,7 @@
     "@types/ember-test-helpers": "^1.0.9",
     "@types/ember-testing-helpers": "^0.0.4",
     "@types/ember__test-helpers": "^1.7.3",
+    "@types/ember__runloop": "^4.0.10",
     "@types/qunit": "^2.9.5",
     "@types/rsvp": "^4.0.3",
     "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/packages/ember-lifeline/src/cancel-task.ts
+++ b/packages/ember-lifeline/src/cancel-task.ts
@@ -82,9 +82,11 @@ export function getTimers(destroyable: Destroyable): Set<EmberRunTimer> {
  */
 export function cancelTask(
   destroyable: Destroyable,
-  cancelId: EmberRunTimer
-): void | undefined {
-  let timers: Set<EmberRunTimer> = getTimers(<Destroyable>destroyable);
+  cancelId: EmberRunTimer | undefined
+): void {
+  let timers: Set<EmberRunTimer | undefined> = getTimers(
+    <Destroyable>destroyable
+  );
 
   timers.delete(cancelId);
   cancel(cancelId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,6 +2748,13 @@
   dependencies:
     "@types/ember__runloop" "^3"
 
+"@types/ember__runloop@^4.0.10":
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/@types/ember__runloop/-/ember__runloop-4.0.10.tgz#7ab893f33128042b61c5712b12500f95d0bb4107"
+  integrity sha512-9MZfOJBXuUP7RqLjovmzy1yY2xKTxVpqHMapqy6QJ8mjAekRmq9IJ+ni2zJ5CWftyb3Lqu3Eks05CL7fnbhcJA==
+  dependencies:
+    "@types/ember" "*"
+
 "@types/ember__service@*":
   version "3.16.1"
   resolved "https://registry.yarnpkg.com/@types/ember__service/-/ember__service-3.16.1.tgz#e8f941ec50ff4a7531487dc60830b4e6c7da6a47"


### PR DESCRIPTION
Ember runloops `cancel` method really does accept `undefined`, but there was a bug in `@types/ember__runloop` which was fix here https://github.com/DefinitelyTyped/DefinitelyTyped/commit/1bf95c454e62bf6cc9ebe009302cef960925eb94