### PR TITLE
Export types from ./types

### DIFF
--- a/packages/ember-lifeline/src/index.ts
+++ b/packages/ember-lifeline/src/index.ts
@@ -10,3 +10,4 @@ export {
 } from './poll-task';
 export { debounceTask, cancelDebounce } from './debounce-task';
 export { getTimeoutOrTestFallback } from './utils/get-timeout-or-test-fallback';
+export * from './types';


### PR DESCRIPTION
It seems this export is missing so that one can also import types like `Destoryable` from `ember-lifeline`, e.g. `
import { type Destroyable } from 'ember-lifeline';`

This likely solves issues #1176 and #1177